### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+ - 1.6.2
+ - tip
+
+script:
+ - go test -v -cover ./... 
+ - go tool vet -shadow=true */


### PR DESCRIPTION
As mentioned previously, go tests were not run automatically. The addition of this travis file should fix it.