### PR TITLE
travis: Adding coverage with coveralls.io external service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *~
 .*.swp
+coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
+sudo: false
 go:
  - 1.6.2
  - tip
-
+before_install:
+ - go get -v github.com/mattn/goveralls
 script:
- - go test -v -cover ./... 
- - go tool vet -shadow=true */
+ - make all cov
+ - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+SHELL := /bin/sh
+GOPROCS := 4
+SRC := $(wildcard *.go)
+COVFILE := coverage.out
+
+.PHONY: all
+all: vet test
+
+.PHONY: clean
+clean:
+	go clean -i ./...
+
+.PHONY: format
+format:
+	go fmt ./...
+
+#.PHONY: cov
+cov: $(COVFILE)
+	go tool cover -func=$(COVFILE)
+
+.PHONY: htmlcov
+htmlcov: $(COVFILE)
+	go tool cover -html=$(COVFILE)
+
+$(COVFILE):
+	go test ./... -covermode=count -coverprofile=$(COVFILE)
+
+.PHONY: test
+test:
+	go test -v ./... -coverprofile=$(COVFILE)
+
+.PHONY: vet
+vet:
+	go vet ./...


### PR DESCRIPTION
Adding coverage via coveralls.io - adding coverage file to gitignore and Makefile to make it easier to use.