### PR TITLE
Update the README with the correct get path - closes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Any contributions are welcome!
 
 To get started, first make sure you've properly set up your Golang environment and then run the
 ```bash
-$ go get github.com/cycloidio/goat
+$ go get github.com/cycloidio/goat/auth0
 ```
 to get the latest version of the [goat](https://github.com/cycloidio/goat/).
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ In order to use the SDK:
 ```go
 import 	"github.com/cycloidio/goat/auth0"
 
-var auth0Domain = https://cycloid.eu.auth0.com // your auth0 domain
-var auth0APIBasePath = /api/v2                 // the API base path
-var auth0Token = "XXXXXX"                      // the token you want to use
+var auth0Domain = "https://cycloid.eu.auth0.com" // your auth0 domain
+var auth0APIBasePath = "/api/v2"                 // the API base path
+var auth0Token = "XXXXXX"                        // the token you want to use
 
 var auth0 = goat.NewAuth0(auth0Domain, auth0APIBasePath, auth0Token)
 ```


### PR DESCRIPTION
As discussed in the issue #12 the get path on the documentation needed to be updated to `go get github.com/cycloidio/goat/auth0` .

Also updated som minor documentation examples (to make them correct go).